### PR TITLE
Added changing color of source node depending on source node state

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -21,7 +21,7 @@
     "eslint-plugin-standard": "^2.0.1",
     "html-webpack-plugin": "^2.28.0",
     "source-map-loader": "^0.1.6",
-    "videocontext": "^0.42.0",
+    "videocontext": "^0.43.0",
     "webpack": "^2.2.1",
     "webpack-dev-server": "^2.4.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import cytoscape from 'cytoscape'
 import cydagre from 'cytoscape-dagre'
 import { createNode, animateNodeChange } from './utils.js'
-import { setEdgeColours, setNodeLabel } from './style.js'
+import { setEdgeColours, setNodeColours, setNodeLabel } from './style.js'
 
 cydagre(cytoscape)
 
@@ -92,6 +92,11 @@ export default class VideoContextVisualisation {
         const edges = this._cy.$(ele => ele.isEdge())
         edges.forEach(edge => {
             setEdgeColours(edge, data)
+        })
+
+        const nodes = this._cy.$(ele => ele.isNode())
+        nodes.forEach(node => {
+            setNodeColours(node, data)
         })
     }
 }

--- a/src/style.js
+++ b/src/style.js
@@ -46,6 +46,22 @@ export function setEdgeColours (edge, data) {
     }
 }
 
+export function setNodeColours (node, data) {
+    const nodeID = node.data().id
+    const nodeData = data[nodeID]
+    const stateStyle = {
+        'waiting': '#444',
+        'sequenced': '#228',
+        'playing': '#080',
+        'paused': '#242',
+        'ended': '#008',
+        'error': '#800',
+    }
+    if (nodeData.state) {
+        node.style('background-color', stateStyle[nodeData.state])
+    }
+}
+
 const formatTransitionInfo = transition => `Start: ${transition.start}s, value ${transition.current}. End: ${transition.end}s, value ${transition.target}`
 
 const formatTransitions = props => {


### PR DESCRIPTION
Simple color changing for source nodes depending on their source state.

A better graphic designer than me should probably improve the color choices in ```setNodeColours``` in style.js.

This closes #7 